### PR TITLE
Run database migrations on deployment, add cron tasks

### DIFF
--- a/.aws/crontasks/run_django_manage_command.sh
+++ b/.aws/crontasks/run_django_manage_command.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Check that exactly one argument was supplied to the script.
+# Exit if there are more or fewer arguments.
+if [[ $# -ne 1 ]]; then
+  echo "run_django_manage_command expected 1 argument; got $# arguments instead:" "$@"
+  echo "Usage: run_django_manage_command <command>"
+  exit 1
+fi
+
+# The command we pass to manage.py is the argument given to the script
+COMMAND=$1
+
+# On the EC2 host, the container names follow the pattern
+# "ecs-<task definition family>-<task definition revision>-<container name in task definition>-<ECS ID string>"
+# Get the Docker ID for the API container by filtering active containers by the
+# name assigned to the container in the task definition.
+API_CONTAINER_ID=$(docker ps --filter "name=django-api" --format "{{.ID}}")
+
+# Check that a container ID was retrieved.
+# If not, print out the Docker containers that are running and exit.
+if [[ -z $API_CONTAINER_ID ]]; then
+  echo -e "Could not find API container ID. Currently running containers:\n$(docker ps)"
+  exit 1
+fi
+
+
+# Run the provided manage.py command in the Django container
+echo "Running command $COMMAND in container $API_CONTAINER_ID..."
+docker exec "$API_CONTAINER_ID" python3 manage.py "$COMMAND"

--- a/.aws/crontasks/service-units/end_all_desk_reservations.service
+++ b/.aws/crontasks/service-units/end_all_desk_reservations.service
@@ -1,0 +1,17 @@
+[Unit]
+Description="Run the end_all_desk_reservations command in the Django container"
+
+# Ensure that the service only runs after the host has networking set up
+After=network.target  
+
+[Service]
+# Make sure that the main process exits before starting consequent units
+Type=oneshot
+
+# Run the task as ec2-user
+User=ec2-user
+ExecStart=/usr/local/bin/run_django_manage_command.sh end_all_desk_reservations
+
+# Send stdout and stderr to journalctl
+StandardOutput=journal
+StandardError=journal

--- a/.aws/crontasks/service-units/send_approver_weekly_approve_reminders.service
+++ b/.aws/crontasks/service-units/send_approver_weekly_approve_reminders.service
@@ -1,0 +1,17 @@
+[Unit]
+Description="Run the send_approver_weekly_approve_reminders command in the Django container"
+
+# Ensure that the service only runs after the host has networking set up
+After=network.target  
+
+[Service]
+# Make sure that the main process exits before starting consequent units
+Type=oneshot
+
+# Run the task as ec2-user
+User=ec2-user
+ExecStart=/usr/local/bin/run_django_manage_command.sh send_approver_weekly_approve_reminders
+
+# Send stdout and stderr to journalctl
+StandardOutput=journal
+StandardError=journal

--- a/.aws/crontasks/service-units/send_daily_helpdesk_timeoff_today_report.service
+++ b/.aws/crontasks/service-units/send_daily_helpdesk_timeoff_today_report.service
@@ -1,0 +1,17 @@
+[Unit]
+Description="Run the send_daily_helpdesk_timeoff_today_report command in the Django container"
+
+# Ensure that the service only runs after the host has networking set up
+After=network.target  
+
+[Service]
+# Make sure that the main process exits before starting consequent units
+Type=oneshot
+
+# Run the task as ec2-user
+User=ec2-user
+ExecStart=/usr/local/bin/run_django_manage_command.sh send_daily_helpdesk_timeoff_today_report
+
+# Send stdout and stderr to journalctl
+StandardOutput=journal
+StandardError=journal

--- a/.aws/crontasks/service-units/send_directors_weekly_approve_reminders.service
+++ b/.aws/crontasks/service-units/send_directors_weekly_approve_reminders.service
@@ -1,0 +1,17 @@
+[Unit]
+Description="Run the send_directors_weekly_approve_reminders command in the Django container"
+
+# Ensure that the service only runs after the host has networking set up
+After=network.target  
+
+[Service]
+# Make sure that the main process exits before starting consequent units
+Type=oneshot
+
+# Run the task as ec2-user
+User=ec2-user
+ExecStart=/usr/local/bin/run_django_manage_command.sh send_directors_weekly_approve_reminders
+
+# Send stdout and stderr to journalctl
+StandardOutput=journal
+StandardError=journal

--- a/.aws/crontasks/service-units/send_employee_transition_report.service
+++ b/.aws/crontasks/service-units/send_employee_transition_report.service
@@ -1,0 +1,17 @@
+[Unit]
+Description="Run the send_employee_transition_report command in the Django container"
+
+# Ensure that the service only runs after the host has networking set up
+After=network.target  
+
+[Service]
+# Make sure that the main process exits before starting consequent units
+Type=oneshot
+
+# Run the task as ec2-user
+User=ec2-user
+ExecStart=/usr/local/bin/run_django_manage_command.sh send_employee_transition_report
+
+# Send stdout and stderr to journalctl
+StandardOutput=journal
+StandardError=journal

--- a/.aws/crontasks/service-units/send_fiscal_weekly_approve_reminders.service
+++ b/.aws/crontasks/service-units/send_fiscal_weekly_approve_reminders.service
@@ -1,0 +1,17 @@
+[Unit]
+Description="Run the send_fiscal_weekly_approve_reminders command in the Django container"
+
+# Ensure that the service only runs after the host has networking set up
+After=network.target  
+
+[Service]
+# Make sure that the main process exits before starting consequent units
+Type=oneshot
+
+# Run the task as ec2-user
+User=ec2-user
+ExecStart=/usr/local/bin/run_django_manage_command.sh send_fiscal_weekly_approve_reminders
+
+# Send stdout and stderr to journalctl
+StandardOutput=journal
+StandardError=journal

--- a/.aws/crontasks/service-units/send_is_timeoff_next_week_report.service
+++ b/.aws/crontasks/service-units/send_is_timeoff_next_week_report.service
@@ -1,0 +1,17 @@
+[Unit]
+Description="Run the send_is_timeoff_next_week_report command in the Django container"
+
+# Ensure that the service only runs after the host has networking set up
+After=network.target  
+
+[Service]
+# Make sure that the main process exits before starting consequent units
+Type=oneshot
+
+# Run the task as ec2-user
+User=ec2-user
+ExecStart=/usr/local/bin/run_django_manage_command.sh send_is_timeoff_next_week_report
+
+# Send stdout and stderr to journalctl
+StandardOutput=journal
+StandardError=journal

--- a/.aws/crontasks/service-units/send_submitter_weekly_revise_reminders.service
+++ b/.aws/crontasks/service-units/send_submitter_weekly_revise_reminders.service
@@ -1,0 +1,17 @@
+[Unit]
+Description="Run the send_submitter_weekly_revise_reminders command in the Django container"
+
+# Ensure that the service only runs after the host has networking set up
+After=network.target  
+
+[Service]
+# Make sure that the main process exits before starting consequent units
+Type=oneshot
+
+# Run the task as ec2-user
+User=ec2-user
+ExecStart=/usr/local/bin/run_django_manage_command.sh send_submitter_weekly_revise_reminders
+
+# Send stdout and stderr to journalctl
+StandardOutput=journal
+StandardError=journal

--- a/.aws/crontasks/service-units/send_weekly_step_reminders.service
+++ b/.aws/crontasks/service-units/send_weekly_step_reminders.service
@@ -1,0 +1,17 @@
+[Unit]
+Description="Run the send_weekly_step_reminders command in the Django container"
+
+# Ensure that the service only runs after the host has networking set up
+After=network.target  
+
+[Service]
+# Make sure that the main process exits before starting consequent units
+Type=oneshot
+
+# Run the task as ec2-user
+User=ec2-user
+ExecStart=/usr/local/bin/run_django_manage_command.sh send_weekly_step_reminders
+
+# Send stdout and stderr to journalctl
+StandardOutput=journal
+StandardError=journal

--- a/.aws/crontasks/timers/end_all_desk_reservations.timer
+++ b/.aws/crontasks/timers/end_all_desk_reservations.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description="Run end_all_desk_reservations.service every day at 6:30 PM"
+
+[Timer]
+OnCalendar=*-*-* 18:30:00 America/Los_Angeles
+# Add a randomized activation delay of up to 1 minute to avoid activating
+# multiple timers at exactly the same time
+RandomizedDelaySec=1m
+
+[Install]
+WantedBy=timers.target

--- a/.aws/crontasks/timers/send_approver_weekly_approve_reminders.timer
+++ b/.aws/crontasks/timers/send_approver_weekly_approve_reminders.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description="Run send_approver_weekly_approve_reminders.service every Monday, Wednesday, and Friday at 3 PM"
+
+[Timer]
+OnCalendar=Mon,Wed,Fri *-*-* 15:00:00 America/Los_Angeles
+# Add a randomized activation delay of up to 1 minute to avoid activating
+# multiple timers at exactly the same time
+RandomizedDelaySec=1m
+
+[Install]
+WantedBy=timers.target

--- a/.aws/crontasks/timers/send_daily_helpdesk_timeoff_today_report.timer
+++ b/.aws/crontasks/timers/send_daily_helpdesk_timeoff_today_report.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description="Run send_daily_helpdesk_timeoff_today_report.service Monday through Friday at 8 AM"
+
+[Timer]
+OnCalendar=Mon..Fri *-*-* 08:00:00 America/Los_Angeles
+# Add a randomized activation delay of up to 1 minute to avoid activating
+# multiple timers at exactly the same time
+RandomizedDelaySec=1m
+
+[Install]
+WantedBy=timers.target

--- a/.aws/crontasks/timers/send_directors_weekly_approve_reminders.timer
+++ b/.aws/crontasks/timers/send_directors_weekly_approve_reminders.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description="Run send_directors_weekly_approve_reminders.service every Friday at 3 PM"
+
+[Timer]
+OnCalendar=Fri *-*-* 15:00:00 America/Los_Angeles
+# Add a randomized activation delay of up to 1 minute to avoid activating
+# multiple timers at exactly the same time
+RandomizedDelaySec=1m
+
+[Install]
+WantedBy=timers.target

--- a/.aws/crontasks/timers/send_employee_transition_report.timer
+++ b/.aws/crontasks/timers/send_employee_transition_report.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description="Run send_employee_transition_report.service every Monday at 8 AM"
+
+[Timer]
+OnCalendar=Mon *-*-* 08:00:00 America/Los_Angeles
+# Add a randomized activation delay of up to 1 minute to avoid activating
+# multiple timers at exactly the same time
+RandomizedDelaySec=1m
+
+[Install]
+WantedBy=timers.target

--- a/.aws/crontasks/timers/send_fiscal_weekly_approve_reminders.timer
+++ b/.aws/crontasks/timers/send_fiscal_weekly_approve_reminders.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description="Run send_fiscal_weekly_approve_reminders.service every Friday at 3 PM"
+
+[Timer]
+OnCalendar=Fri *-*-* 15:00:00 America/Los_Angeles
+# Add a randomized activation delay of up to 1 minute to avoid activating
+# multiple timers at exactly the same time
+RandomizedDelaySec=1m
+
+[Install]
+WantedBy=timers.target

--- a/.aws/crontasks/timers/send_is_timeoff_next_week_report.timer
+++ b/.aws/crontasks/timers/send_is_timeoff_next_week_report.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description="Run send_is_timeoff_next_week_report.service every Friday at 8 AM"
+
+[Timer]
+OnCalendar=Fri *-*-* 08:00:00 America/Los_Angeles
+# Add a randomized activation delay of up to 1 minute to avoid activating
+# multiple timers at exactly the same time
+RandomizedDelaySec=1m
+
+[Install]
+WantedBy=timers.target

--- a/.aws/crontasks/timers/send_submitter_weekly_revise_reminders.timer
+++ b/.aws/crontasks/timers/send_submitter_weekly_revise_reminders.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description="Run send_submitter_weekly_revise_reminders.service every Friday at 3 PM"
+
+[Timer]
+OnCalendar=Fri *-*-* 15:00:00 America/Los_Angeles
+# Add a randomized activation delay of up to 1 minute to avoid activating
+# multiple timers at exactly the same time
+RandomizedDelaySec=1m
+
+[Install]
+WantedBy=timers.target

--- a/.aws/crontasks/timers/send_weekly_step_reminders.timer
+++ b/.aws/crontasks/timers/send_weekly_step_reminders.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description="Run send_weekly_step_reminders.service every Monday at 8 AM"
+
+[Timer]
+OnCalendar=Mon *-*-* 08:00:00 America/Los_Angeles
+# Add a randomized activation delay of up to 1 minute to avoid activating
+# multiple timers at exactly the same time
+RandomizedDelaySec=1m
+
+[Install]
+WantedBy=timers.target

--- a/.aws/lcog-team-staging-backend-task-definition.json
+++ b/.aws/lcog-team-staging-backend-task-definition.json
@@ -60,7 +60,7 @@
         }
       ],
       "essential": true,
-      "image": "311127195930.dkr.ecr.us-west-2.amazonaws.com/backend/api:2025.10.21-9248a73",
+      "image": "311127195930.dkr.ecr.us-west-2.amazonaws.com/backend/api:2025.10.31-757798f",
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
@@ -184,7 +184,7 @@
         }
       ],
       "essential": false,
-      "image": "311127195930.dkr.ecr.us-west-2.amazonaws.com/backend/api:2025.10.21-9248a73",
+      "image": "311127195930.dkr.ecr.us-west-2.amazonaws.com/backend/api:2025.10.31-757798f",
       "command": [
         "python",
         "manage.py",

--- a/.aws/lcog-team-staging-backend-task-definition.json
+++ b/.aws/lcog-team-staging-backend-task-definition.json
@@ -80,7 +80,14 @@
           "sourceVolume": "static"
         }
       ],
-      "portMappings": [],
+      "portMappings": [
+        {
+          "containerPort": 587,
+          "hostPort": 587,
+          "name": "email-smtp-starttls",
+          "protocol": "tcp"
+        }
+      ],
       "systemControls": [],
       "ulimits": [],
       "volumesFrom": []

--- a/.aws/lcog-team-staging-backend-task-definition.json
+++ b/.aws/lcog-team-staging-backend-task-definition.json
@@ -49,6 +49,14 @@
         {
           "name": "RDS_DB_NAME",
           "valueFrom": "arn:aws:secretsmanager:us-west-2:311127195930:secret:TeamApp/staging/Postgres-PfZ0yh:dbname::"
+        },
+        {
+          "name": "SES_EMAIL_HOST_USER",
+          "valueFrom": "arn:aws:secretsmanager:us-west-2:311127195930:secret:TeamApp/Email-5DYABy:SES_EMAIL_HOST_USER::"
+        },
+        {
+          "name": "SES_EMAIL_HOST_PASSWORD",
+          "valueFrom": "arn:aws:secretsmanager:us-west-2:311127195930:secret:TeamApp/Email-5DYABy:SES_EMAIL_HOST_PASSWORD::"
         }
       ],
       "essential": true,

--- a/.aws/lcog-team-staging-backend-task-definition.json
+++ b/.aws/lcog-team-staging-backend-task-definition.json
@@ -2,6 +2,7 @@
   "family": "lcog-team-app-staging-backend-td",
   "containerDefinitions": [
     {
+      "name": "django-api",
       "cpu": 512,
       "environment": [],
       "environmentFiles": [
@@ -65,13 +66,13 @@
           "sourceVolume": "static"
         }
       ],
-      "name": "django-api",
       "portMappings": [],
       "systemControls": [],
       "ulimits": [],
       "volumesFrom": []
     },
     {
+      "name": "nginx",
       "cpu": 512,
       "dependsOn": [
         {
@@ -105,7 +106,6 @@
           "sourceVolume": "static"
         }
       ],
-      "name": "nginx",
       "portMappings": [
         {
           "appProtocol": "http",

--- a/.aws/lcog-team-staging-backend-task-definition.json
+++ b/.aws/lcog-team-staging-backend-task-definition.json
@@ -4,6 +4,12 @@
     {
       "name": "django-api",
       "cpu": 512,
+      "dependsOn": [
+        {
+          "condition": "SUCCESS",
+          "containerName": "run-migrations"
+        }
+      ],
       "environment": [],
       "environmentFiles": [
         {
@@ -115,6 +121,75 @@
           "protocol": "tcp"
         }
       ],
+      "systemControls": [],
+      "volumesFrom": []
+    },
+    {
+      "name": "run-migrations",
+      "cpu": 0,
+      "environment": [],
+      "environmentFiles": [
+        {
+          "type": "s3",
+          "value": "arn:aws:s3:::team-app.config/staging/.staging.env"
+        }
+      ],
+      "secrets": [
+        {
+          "name": "SECRET_KEY",
+          "valueFrom": "arn:aws:secretsmanager:us-west-2:311127195930:secret:TeamApp/DjangoSecretKey-zd3Nob:SECRET_KEY::"
+        },
+        {
+          "name": "AWS_ACCESS_KEY_ID",
+          "valueFrom": "arn:aws:secretsmanager:us-west-2:311127195930:secret:TeamApp/AWSCloudWatchAndS3-P1a6Ks:AWS_ACCESS_KEY_ID::"
+        },
+        {
+          "name": "AWS_SECRET_ACCESS_KEY",
+          "valueFrom": "arn:aws:secretsmanager:us-west-2:311127195930:secret:TeamApp/AWSCloudWatchAndS3-P1a6Ks:AWS_SECRET_ACCESS_KEY::"
+        },
+        {
+          "name": "RDS_PASSWORD",
+          "valueFrom": "arn:aws:secretsmanager:us-west-2:311127195930:secret:TeamApp/staging/Postgres-PfZ0yh:password::"
+        },
+        {
+          "name": "RDS_USERNAME",
+          "valueFrom": "arn:aws:secretsmanager:us-west-2:311127195930:secret:TeamApp/staging/Postgres-PfZ0yh:username::"
+        },
+        {
+          "name": "RDS_HOSTNAME",
+          "valueFrom": "arn:aws:secretsmanager:us-west-2:311127195930:secret:TeamApp/staging/Postgres-PfZ0yh:host::"
+        },
+        {
+          "name": "RDS_PORT",
+          "valueFrom": "arn:aws:secretsmanager:us-west-2:311127195930:secret:TeamApp/staging/Postgres-PfZ0yh:port::"
+        },
+        {
+          "name": "RDS_DB_NAME",
+          "valueFrom": "arn:aws:secretsmanager:us-west-2:311127195930:secret:TeamApp/staging/Postgres-PfZ0yh:dbname::"
+        }
+      ],
+      "essential": false,
+      "image": "311127195930.dkr.ecr.us-west-2.amazonaws.com/backend/api:2025.10.21-9248a73",
+      "command": [
+        "python",
+        "manage.py",
+        "migrate",
+        "--no-input",
+        "--verbosity",
+        "3"
+      ],
+      "mountPoints": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/lcog-team-staging-backend",
+          "awslogs-create-group": "true",
+          "awslogs-region": "us-west-2",
+          "awslogs-stream-prefix": "ecs"
+        },
+        "secretOptions": []
+      },
+      "portMappings": [],
       "systemControls": [],
       "volumesFrom": []
     }

--- a/.dockerignore
+++ b/.dockerignore
@@ -51,3 +51,6 @@ db.sqlite3
 
 # Do not copy the settings_local.py file
 mainsite/settings_local.py
+
+# Do not copy any script files to the image
+**/*.sh

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ people/management/employees.csv
 people/management/reviews.csv
 
 .python-version
+.aws/team-app-crontasks.tar.gz

--- a/build_and_deploy_staging_api.sh
+++ b/build_and_deploy_staging_api.sh
@@ -41,7 +41,10 @@ if ! command -v jq >/dev/null; then
 else
     echo "Updating the image version in task definition file $TDFILE ..."
   # Update task definition with new image version
+    # Update image version for main Django container
     cat <<< "$(jq --arg image "$REPO_URI:$API_VERSION" '.containerDefinitions[0].image = $image' $TDFILE)" > "$TDFILE"
+    # Update image version for migrations container
+    cat <<< "$(jq --arg image "$REPO_URI:$API_VERSION" '.containerDefinitions[2].image = $image' $TDFILE)" > "$TDFILE"
     echo "Finished updating image version $REPO_URI:$API_VERSION in task definition $TDFILE"
 fi
 

--- a/build_and_deploy_staging_api.sh
+++ b/build_and_deploy_staging_api.sh
@@ -13,21 +13,23 @@ REPO_URI="311127195930.dkr.ecr.us-west-2.amazonaws.com/backend/api"
 # Get the login password for the ECR and pass it to Docker to allow pushing
 # to the ECR repository
 echo "Retrieving ECR login password and logging in to Docker..."
-aws ecr get-login-password --profile $AWS_PROFILE \
+aws ecr get-login-password --profile "$AWS_PROFILE" \
   | docker login --username AWS --password-stdin 311127195930.dkr.ecr.us-west-2.amazonaws.com
 
 # Build and push the container image using Docker CLI
+# Use current date and short form of Git HEAD commit SHA for API version number:
+# YYYY.MM.DD-1a2b3c4
 API_VERSION=$(date -I | tr - .)-$(git rev-parse --short HEAD)
 echo "Building API image with version $API_VERSION ..."
-docker build -t backend/api:$API_VERSION .
+docker build -t "backend/api:$API_VERSION" .
 echo "Finished building backend/api:$API_VERSION"
 
 echo "Tagging image with ECR repository URI..."
-docker tag backend/api:$API_VERSION $REPO_URI:$API_VERSION
+docker tag "backend/api:$API_VERSION" "$REPO_URI:$API_VERSION"
 echo "Finished tagging image"
 
 echo "Pushing image to ECR repository $REPO_URI ..."
-docker push $REPO_URI:$API_VERSION
+docker push "$REPO_URI:$API_VERSION"
 echo "Finished pushing image to ECR at $REPO_URI:$API_VERSION"
 
 # Task definition file
@@ -36,7 +38,7 @@ TDFILE=.aws/lcog-team-staging-backend-task-definition.json
 # Check if jq is installed and task definition can be updated automatically
 echo "Checking if jq is installed..."
 if ! command -v jq >/dev/null; then
-  echo "\nIt looks like jq is not installed; cannot automatically update the image version in the task definition file $TDFILE.\n\nEdit the task definition file manually and then run the ECS deployment commands manually."
+  echo -e "\nIt looks like jq is not installed; cannot automatically update the image version in the task definition file $TDFILE.\n\nEdit the task definition file manually and then run the ECS deployment commands manually."
   exit 1
 else
     echo "Updating the image version in task definition file $TDFILE ..."

--- a/compose.yaml
+++ b/compose.yaml
@@ -27,13 +27,13 @@ services:
         source: db.sqlite3
         target: /app/db.sqlite3
     env_file:
-      - ".env"
+      - ".develop.env"
     ports:
       - 8000:8000
     
   nginx:
     image: nginx:1.29.1
-    container_name: reverse-proxy
+    container_name: nginx
     build:
       context: ./.nginx
       dockerfile: Dockerfile
@@ -44,7 +44,8 @@ services:
           path: .nginx/nginx.conf
           target: /etc/nginx/nginx.conf
     depends_on:
-      - api
+      api:
+        condition: service_started
     # configs:
     #   - source: nginx_config
     #     target: /etc/nginx/nginx.conf

--- a/compose.yaml
+++ b/compose.yaml
@@ -56,6 +56,13 @@ services:
     ports:
       - 8080:80
 
+  migrations:
+     image: lcogteam-backend-django
+     container_name: run-migrations
+     command: python manage.py migrate
+
+
+
 # configs:
 #   nginx_config:
 #     file: ./.nginx/nginx.conf

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,6 +5,9 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
+    depends_on:
+      migrations:
+        condition: service_completed_successfully
     develop:
       watch:
         # Synchronize changes with running Django API container when making
@@ -23,6 +26,8 @@ services:
       - type: volume
         source: static
         target: /app/static
+      # For local development, load the sqlite db file and local settings file
+      # to the container
       - type: bind
         source: db.sqlite3
         target: /app/db.sqlite3
@@ -61,9 +66,15 @@ services:
       - 8080:80
 
   migrations:
-     image: lcogteam-backend-django
-     container_name: run-migrations
-     command: python manage.py migrate
+    image: lcogteam-backend-django
+    container_name: run-migrations
+    command: python manage.py migrate --no-input --verbosity 3
+    volumes:
+      - type: bind
+        source: db.sqlite3
+        target: /app/db.sqlite3
+    env_file:
+      - .develop.env
 
 
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -26,6 +26,9 @@ services:
       - type: bind
         source: db.sqlite3
         target: /app/db.sqlite3
+      - type: bind
+        source: mainsite/settings_local.py
+        target: /app/mainsite/settings_local.py
     env_file:
       - ".develop.env"
     ports:

--- a/mainsite/settings.py
+++ b/mainsite/settings.py
@@ -46,6 +46,7 @@ if ENVIRONMENT == 'STAGING':
         'app.team-staging.lcog.org', # Staging frontend
         'api.team-staging.lcog.org', # Staging backend
     ]
+    CSRF_TRUSTED_ORIGINS = ['https://api.team-staging.lcog.org']
 else:
     # PRODUCTION
     ALLOWED_HOSTS = [


### PR DESCRIPTION
This PR contains the following changes:

- add a container that runs database migrations before the application server starts on deployment to ECS and locally in Docker Compose
- add Team App cron tasks and configuration for sending emails from the container in ECS
- correctly adds local Django settings in Docker Compose by loading `settings_local.py` into the container
- fixes a CSRF issue in accessing the Django admin panel and updates the ECS task definition with new image version