### PR TITLE
Check for system architecture when building Docker image

### DIFF
--- a/build_and_deploy_staging_api.sh
+++ b/build_and_deploy_staging_api.sh
@@ -10,6 +10,13 @@ if ! command -v jq >/dev/null; then
   exit 1
 fi
 
+echo "Checking build system architecture..."
+arch=$(uname --machine)
+echo "Found $arch"
+if [[ $arch != x86_64 ]]; then
+  echo "Looks like you are building the Docker image on an $arch architecture. The target platform is linux/x86_64. Make sure you have the virtual machine tools in place for building x86_64 images or build the image on a different system."
+fi
+
 # Set AWS profile for logging in to Docker and pushing the image
 AWS_PROFILE=${AWS_PROFILE:?Set the AWS_PROFILE variable to your ECS developer profile: export AWS_PROFILE=<AWS profile name>}
 echo "Using AWS profile $AWS_PROFILE"

--- a/build_and_deploy_staging_api.sh
+++ b/build_and_deploy_staging_api.sh
@@ -21,7 +21,7 @@ aws ecr get-login-password --profile "$AWS_PROFILE" \
 # YYYY.MM.DD-1a2b3c4
 API_VERSION=$(date -I | tr - .)-$(git rev-parse --short HEAD)
 echo "Building API image with version $API_VERSION ..."
-docker build -t "backend/api:$API_VERSION" .
+docker build --platform linux/amd64 -t "backend/api:$API_VERSION" .
 echo "Finished building backend/api:$API_VERSION"
 
 echo "Tagging image with ECR repository URI..."

--- a/build_and_deploy_staging_api.sh
+++ b/build_and_deploy_staging_api.sh
@@ -21,7 +21,7 @@ aws ecr get-login-password --profile "$AWS_PROFILE" \
 # YYYY.MM.DD-1a2b3c4
 API_VERSION=$(date -I | tr - .)-$(git rev-parse --short HEAD)
 echo "Building API image with version $API_VERSION ..."
-docker build --platform linux/amd64 -t "backend/api:$API_VERSION" .
+docker build --platform linux/amd64 --tag "backend/api:$API_VERSION" .
 echo "Finished building backend/api:$API_VERSION"
 
 echo "Tagging image with ECR repository URI..."


### PR DESCRIPTION
The Docker images in AWS ECS use target the `linux/amd64` platform. To make sure that we're pushing images that have been built for the correct architecture, this PR:

- adds a check for the build system architecture and outputs the result
- adds the target platform to the `docker build` command